### PR TITLE
Minor refactoring, new RNG options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 # Pre-setup
-cmake_minimum_required(VERSION 3.19.0)
+cmake_minimum_required(VERSION 3.18.0)
 include(cmake/cable/bootstrap.cmake)
 include(CableBuildInfo)
 include(CableBuildType)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
 # Pre-setup
-cmake_minimum_required(VERSION 3.18.0)
+cmake_minimum_required(VERSION 3.19.0)
 include(cmake/cable/bootstrap.cmake)
 include(CableBuildInfo)
 include(CableBuildType)

--- a/src/core/BIP39.cpp
+++ b/src/core/BIP39.cpp
@@ -43,7 +43,7 @@ std::pair<bool,std::string> BIP39::saveEncryptedMnemonic(
   // Initialize the seed json and cipher, then create the salt
   json seedJson;
   Cipher cipher("aes-256-cbc", "sha256");
-  unsigned char saltBytes[32];
+  unsigned char saltBytes[CIPHER_SALT_BYTES] = {0}; /*Use exactly as many bytes for the cipher as needed.*/
 	/*
 		Use std::random_device (thin wrapper around /dev/urandom) on linux, it is the most
 		secure source of entropy on the system.
@@ -72,10 +72,21 @@ std::pair<bool,std::string> BIP39::saveEncryptedMnemonic(
 #endif
 #endif
   
-  
+   /*
+  	@GEK bugfix- you were taking your 32 bytes of perfectly good randomness, and 
+  	reducing them down to 4 (as 8 hex digits).
+  */
+
+	
+  /*
   std::string salt = toHex(
     dev::sha3(std::string((char*)saltBytes, sizeof(saltBytes)), false)
-  ).substr(0,8);
+  ).substr(0,8);*/
+  std::string salt; /**/
+  for(int i = 0; i < CIPHER_SALT_BYTES; i++)
+  	salt.push_back(' '); /*make it big enough to hold the salt. This also guarantees null termination.*/
+
+  memcpy((char*)salt.c_str(), saltBytes, CIPHER_SALT_BYTES); /*Memcpy it in.*/
 
   // Encrypt the mnemonic
   std::string encryptedPhrase;

--- a/src/core/Cipher.cpp
+++ b/src/core/Cipher.cpp
@@ -423,7 +423,20 @@ void Cipher::set_salt(const string& salt)
 {
   DBG_FCT("set_salt");
   if (salt.length() == 0) {
-  	std::random_device rd;
+	/*
+		use mersenne twister on windows seeded from random_device on windows,
+		because it does not have /dev/urandom
+	*/
+#ifdef __linux__
+	/*
+		Cryptographically, /dev/urandom has the most entropy in it,
+		so it will be the most secure source of random data.
+	*/
+	std::random_device rd;  	
+#else
+
+	std::mt19937 rd(std::random_device{}());
+#endif
   	/*
 		Seed with some pseudo-random-data.
   	*/

--- a/src/core/Cipher.cpp
+++ b/src/core/Cipher.cpp
@@ -441,18 +441,18 @@ void Cipher::set_salt(const string& salt)
 		Seed with some pseudo-random-data.
   	*/
     // Choose a random salt.
-    for(uint i=0;i<sizeof(m_salt);++i) {
+    for(uint i=0;i<CIPHER_SALT_BYTES;++i) {
       m_salt[i] = /*rand() % 256*/ rd() % 256;
     }
   }
-  else if (salt.length() == 8) {
-    memcpy(m_salt, salt.c_str(), 8);
+  else if (salt.length() == CIPHER_SALT_BYTES) {
+    memcpy(m_salt, salt.c_str(), CIPHER_SALT_BYTES);
   }
-  else if (salt.length()<8) {
-    throw underflow_error("init(): salt is too short, must be 8 characters");
+  else if (salt.length()<CIPHER_SALT_BYTES) {
+    throw underflow_error("init(): salt is too short, must be CIPHER_SALT_BYTES characters");
   }
-  else if (salt.length()>8) {
-    throw overflow_error("init(): salt is too long, must be 8 characters");
+  else if (salt.length()>CIPHER_SALT_BYTES) {
+    throw overflow_error("init(): salt is too long, must be CIPHER_SALT_BYTES characters");
   }
 }
 

--- a/src/core/Cipher.h
+++ b/src/core/Cipher.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 #include <utility> // pair
+#include <random> //  random_device and mersenne twister mt19937
 
 #define CIPHER_DEFAULT_CIPHER "aes-256-cbc"
 #define CIPHER_DEFAULT_DIGEST "sha256"

--- a/src/core/Cipher.h
+++ b/src/core/Cipher.h
@@ -72,6 +72,9 @@
  * @endcode
  * @author Joe Linoff
  */
+
+#define CIPHER_SALT_BYTES 8
+ 
 class Cipher
 {
 public:
@@ -79,7 +82,7 @@ public:
   typedef unsigned char uchar;
   typedef uchar aes_key_t[32];
   typedef uchar aes_iv_t[32];
-  typedef uchar aes_salt_t[8];
+  typedef uchar aes_salt_t[CIPHER_SALT_BYTES]; /*TODO: make this 32 bytes.*/
   typedef std::pair<uchar*,uint> kv1_t;
 public:
   /**


### PR DESCRIPTION
I have chosen to use std::random_device on linux only, however the mersenne twister (mt19937) can be used seeded from std::random_device if necessary.

On windows, though, this might not be cryptographically secure.

So, the default on windows is to use the SSL functions you already use.

I do not think it is possible for SSL to have a more secure source of entropy than /dev/urandom.