### PR TITLE
QML: Declare and use QmlSystem class from C++, not from QML

### DIFF
--- a/src/main-gui.cpp
+++ b/src/main-gui.cpp
@@ -21,7 +21,11 @@ int main(int argc, char *argv[]) {
   // Create the actual application and register our custom classes into it
   QApplication app(argc, argv);
   QQmlApplicationEngine engine;
-  qmlRegisterType<QmlSystem>("QmlSystem", 1, 0, "QmlSystem");
+
+  QmlSystem qmlsystem;
+  qmlsystem.setEngine(&engine);
+
+  engine.rootContext()->setContextProperty("qmlSystem", &qmlsystem);
   qmlRegisterType<QmlApi>("QmlApi", 1, 0, "QmlApi");
 
   // Set the app's text font and icon
@@ -36,7 +40,7 @@ int main(int argc, char *argv[]) {
   // Load the main screen, link the required signals/slots and start the app
   engine.load(QUrl(QStringLiteral("qrc:/qml/screens/main.qml")));
   if (engine.rootObjects().isEmpty()) return -1;
-  QmlSystem qmlsystem;
+
   QObject::connect(&app, SIGNAL(aboutToQuit()), &qmlsystem, SLOT(cleanAndClose()));
   return app.exec();
 }

--- a/src/qml/components/AVMESideMenu.qml
+++ b/src/qml/components/AVMESideMenu.qml
@@ -151,7 +151,7 @@ Rectangle {
       width: (parent.width * 0.8)
       anchors.horizontalCenter: parent.horizontalCenter
       text: "Applications (WIP)"
-      enabled: (enableBtn && false) // TODO: re-enable when implementing DApps
+      // enabled: (enableBtn && false) // TODO: re-enable when implementing DApps
       onClicked: {
         itemSelection.y = items.y + y
         changeScreen("Applications")

--- a/src/qml/screens/AppScreen.qml
+++ b/src/qml/screens/AppScreen.qml
@@ -14,6 +14,8 @@ Item {
     target: qmlSystem
     function onAppLoaded(folderPath) {
       folder = folderPath
+      appContent.source = "" // trimComponentCache can *only* be called after setting the source to ""
+      qmlSystem.trimComponentCache()
       qmlSystem.setLocalScreen(appContent, folder + "/main.qml")
     }
   }

--- a/src/qml/screens/main.qml
+++ b/src/qml/screens/main.qml
@@ -5,7 +5,6 @@ import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Window 2.2
 
-import QmlSystem 1.0
 import QmlApi 1.0
 
 import "qrc:/qml/components"
@@ -16,7 +15,6 @@ ApplicationWindow {
   property bool menuToggle: false
   property alias menuSize: sideMenu.width
 
-  QmlSystem { id: qmlSystem }
   QmlApi { id: qmlApi }
 
   title: "AVME Wallet " + qmlSystem.getProjectVersion()

--- a/src/qmlwrap/QmlSystem.cpp
+++ b/src/qmlwrap/QmlSystem.cpp
@@ -18,9 +18,7 @@ void QmlSystem::setScreen(QObject* loader, QString qmlFile) {
 
 void QmlSystem::setLocalScreen(QObject* loader, QString qmlFile) {
   loader->setProperty(
-    "source", "file:" + qmlFile + "?t=" + QString::number(
-      QDateTime::currentMSecsSinceEpoch(), 10
-    )
+    "source", "file:" + qmlFile
   );
 }
 

--- a/src/qmlwrap/QmlSystem.h
+++ b/src/qmlwrap/QmlSystem.h
@@ -40,6 +40,7 @@ class QmlSystem : public QObject {
     bool ledgerFlag = false;
     QString currentHardwareAccount;
     QString currentHardwareAccountPath;
+    QQmlApplicationEngine *engine = nullptr;
 
   public slots:
     // Clean database, threads, etc before closing the program
@@ -109,7 +110,13 @@ class QmlSystem : public QObject {
     Q_INVOKABLE QString getCurrentHardwareAccount() { return currentHardwareAccount; }
     Q_INVOKABLE void setCurrentHardwareAccountPath(QString b) { currentHardwareAccountPath = b; }
     Q_INVOKABLE QString getCurrentHardwareAccountPath() { return currentHardwareAccountPath; }
+    void setEngine(QQmlApplicationEngine *targetEngine) { engine = targetEngine;}; // INVOKATION FROM QML SHOULD *NOT* BE ALLOWED!
 
+    // Trim component cache
+    // Removes *only* the data not being used
+    Q_INVOKABLE void trimComponentCache() {
+      engine->trimComponentCache();
+    }
     // Get the project's version
     Q_INVOKABLE QString getProjectVersion();
 


### PR DESCRIPTION
## Issue and Motivation

Currently, the QmlSystem class is being declared from the QML side of the program, causing a problem with https://github.com/avme/avme-wallet/blob/main/src/main-gui.cpp#L40, where it is referencing to an empty class (QmlSystem declared in C++ is not the same as declared with qmlRegisterType), causing a Segmentation Fault.
As we are in the final touches for the modularized system, we noticed a flaw as we need access to the QQmlApplicationEngine to clear the cache of the desired screen. Unfortunately, it is impossible to set a pointer to the QQmlApplicationEngine declared in the C++ side from the QML side, without using really messy code.
As QmlSystem should be accessible by the whole program, it doesn't make sense to declare it as a qmlRegisterType. 
See video for more information:

https://user-images.githubusercontent.com/32653934/132332751-ca20e784-eb2b-4a08-a988-9ef341023626.mp4

## Solution

The solution is go back to use engine.rootContext()->setContextProperty("qmlSystem", &qmlsystem);
Where is it possible to feed a class created in C++, where we would be giving a pointer to the engine itself. See attached video.

https://user-images.githubusercontent.com/32653934/132332879-b11f98a4-527c-4e33-b83e-51f8702029bf.mp4

@Jean-Lessa, I would like your opinion over this, as we have previously discussed the idea of using qmlRegisterType vs. setContextProperty. 
